### PR TITLE
Jstep/handle keep alive response

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -155,7 +155,7 @@ class DefinedRealtimeClient {
         ) as DefinedWebSocketSubscriptionResponse<any>;
         // Guard: Not the right shape of message, something went wrong and we don't know how to handle it.
         // Every good message should have at least an 'id'.
-        if (!json.id) {
+        if (!json.id && json.type !== 'ka') {
           console.warn('Unrecognized websocket message', json.payload.errors);
           return;
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,7 @@ export interface DefinedWebSocketDataPayload<T> {
 
 export interface DefinedWebSocketSubscriptionResponse<T> {
   id: string;
-  type: 'data' | 'start_ack' | 'error';
+  type: 'data' | 'start_ack' | 'error' | 'ka' | 'complete';
   payload: DefinedWebSocketDataPayload<T>;
 }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -28,9 +28,11 @@ describe('definedfi-ws', () => {
   it('should connect and disconnect to the websocket endpoint without error', async () => {
     const definedWs = new DefinedRealtimeClient(TEST_API_KEY);
     await definedWs.connect();
-    expect(definedWs.wsLazySingleton?.readyState).toBe(1); // Connected
+    expect(definedWs.wsLazySingleton?.readyState).toBe(1); // OPEN
     await definedWs.disconnect();
-    expect(definedWs.wsLazySingleton?.readyState).toBe(3); // Is 3 okay? am i terminating the session correctly?
+    expect(definedWs.wsLazySingleton?.readyState).toBe(
+      definedWs.wsLazySingleton?.CLOSED
+    );
   });
 
   it('should connect and subscribe to token price updates successfully', async () => {


### PR DESCRIPTION
The keep-alive response from the server was messing up this guard, so I just added to it to check for `{type: ka}`. LMK if you have a better solution, but in my testing this kept it from crashing on keep-alive responses.

Also addressed your comment/question in the tests about the ready state after reading this: https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/readyState#value